### PR TITLE
Add /health endpoint and remove disk cache

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ dev = [
 
 server = [
     "fastapi",
-    "diskcache",
     "uvicorn[standard]",
 ]
 

--- a/signwriting_description/server.py
+++ b/signwriting_description/server.py
@@ -1,4 +1,5 @@
 import os
+from datetime import UTC, datetime
 
 import uvicorn
 from dotenv import load_dotenv
@@ -19,7 +20,11 @@ app = FastAPI(title="Signwriting Description API")
 
 @app.get("/health")
 def health():
-    return {"status": "ok"}
+    return {
+        "status": "healthy",
+        "timestamp": datetime.now(tz=UTC).isoformat(),
+        "service": "signwriting-description",
+    }
 
 
 @app.get("/")

--- a/signwriting_description/server.py
+++ b/signwriting_description/server.py
@@ -1,8 +1,4 @@
-from __future__ import annotations
-
-import hashlib
 import os
-from pathlib import Path
 
 import uvicorn
 from dotenv import load_dotenv
@@ -18,17 +14,12 @@ OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 if not OPENAI_API_KEY:
     raise RuntimeError("Missing OPENAI_API_KEY environment variable")
 
-DISKCACHE_DIR = os.getenv("DISK_CACHE_DIR")
-cache: Cache | None = None
-if DISKCACHE_DIR:
-    from diskcache import Cache
-
-    path = Path(DISKCACHE_DIR).expanduser()
-    print("Using disk cache at", path)
-    path.mkdir(parents=True, exist_ok=True)
-    cache = Cache(str(path))
-
 app = FastAPI(title="Signwriting Description API")
+
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}
 
 
 @app.get("/")
@@ -38,7 +29,6 @@ def signwriting_description(
     if not fsw:
         raise HTTPException(status_code=400, detail="Missing `fsw` parameter")
 
-    # Validate FSW parses and isn't empty
     try:
         sign = fsw_to_sign(fsw)
     except Exception as e:
@@ -47,31 +37,9 @@ def signwriting_description(
     if not sign or len(sign.get("symbols", [])) == 0:
         raise HTTPException(status_code=400, detail="Empty `fsw` property")
 
-    fsw_hash = hashlib.md5(fsw.encode("utf-8")).hexdigest()
-    key = f"descriptions:{fsw_hash}"
-    print("Cache key:", key)
+    description = describe_sign(fsw)
 
-    description = None
-    cache_hit = False
-
-    if cache is not None:
-        cached: str | None = cache.get(key)
-        if cached is not None:
-            print("Cache hit")
-            description, cache_hit = cached, True
-
-    if description is None:
-        print("Input:", fsw)
-        description = describe_sign(fsw)
-        print("Output:", description)
-
-        if cache is not None:
-            cache.set(key, description)
-
-    resp = JSONResponse(content={
-        "description": description,
-        "cache_hit": cache_hit
-    })
+    resp = JSONResponse(content={"description": description})
     resp.headers["Cache-Control"] = "public, max-age=2592000"  # 30 days
     return resp
 


### PR DESCRIPTION
## Summary
- Add `/health` endpoint for Cloud Run liveness probes
- Remove `diskcache` dependency and all disk caching logic (no longer needed)
- Remove `cache_hit` field from response

## Test plan
- [ ] Verify `/health` returns `{"status": "ok"}`
- [ ] Verify `GET /?fsw=...` still returns descriptions correctly
- [ ] Verify Docker image builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)