### PR TITLE
fix: add missing regex dependency

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,3 +34,10 @@ jobs:
 
       - name: Build Docker image
         run: docker build -t signwriting-description .
+
+      - name: Smoke test /health endpoint
+        run: |
+          docker run -d --name smoke -e PORT=8080 -e OPENAI_API_KEY=test -p 8080:8080 signwriting-description
+          for i in 1 2 3 4 5; do curl -sf http://localhost:8080/health && exit 0; sleep 2; done
+          docker logs smoke
+          exit 1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,6 +38,5 @@ jobs:
       - name: Smoke test /health endpoint
         run: |
           docker run -d --name smoke -e PORT=8080 -e OPENAI_API_KEY=test -p 8080:8080 signwriting-description
-          for i in 1 2 3 4 5; do curl -sf http://localhost:8080/health && exit 0; sleep 2; done
-          docker logs smoke
-          exit 1
+          sleep 5 # wait for uvicorn cold start
+          curl -sf http://localhost:8080/health

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,3 +24,13 @@ jobs:
 
       - name: Test Code
         run: pytest signwriting_description
+
+  docker-build:
+    name: Docker Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build Docker image
+        run: docker build -t signwriting-description .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "Pillow",
     "openai>=1.8.0",
     "python-dotenv",
+    "regex",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- The `signwriting` package depends on `regex` but doesn't declare it as a transitive dependency
- This causes the container to crash on startup: `ModuleNotFoundError: No module named 'regex'`
- Adding `regex` explicitly to `pyproject.toml` fixes the issue

## Test plan
- [x] Verified container crashes without the fix
- [x] Verified container starts and `/health` returns 200 with the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)