### PR TITLE
Add Cloudflare Turnstile verification middleware

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,6 +37,6 @@ jobs:
 
       - name: Smoke test /health endpoint
         run: |
-          docker run -d --name smoke -e PORT=8080 -e OPENAI_API_KEY=test -e TURNSTILE_SECRET_KEY=test -p 8080:8080 signwriting-description
+          docker run -d --name smoke -e PORT=8080 -e OPENAI_API_KEY=test -e TURNSTILE_SECRET_KEY=1x0000000000000000000000000000000AA -p 8080:8080 signwriting-description
           sleep 5 # wait for uvicorn cold start
           curl -sf http://localhost:8080/health

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,6 +37,6 @@ jobs:
 
       - name: Smoke test /health endpoint
         run: |
-          docker run -d --name smoke -e PORT=8080 -e OPENAI_API_KEY=test -p 8080:8080 signwriting-description
+          docker run -d --name smoke -e PORT=8080 -e OPENAI_API_KEY=test -e TURNSTILE_SECRET_KEY=test -p 8080:8080 signwriting-description
           sleep 5 # wait for uvicorn cold start
           curl -sf http://localhost:8080/health

--- a/signwriting_description/server.py
+++ b/signwriting_description/server.py
@@ -1,9 +1,10 @@
 import os
 from datetime import UTC, datetime
 
+import httpx
 import uvicorn
 from dotenv import load_dotenv
-from fastapi import FastAPI, HTTPException, Query
+from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 from signwriting.formats.fsw_to_sign import fsw_to_sign
 
@@ -15,7 +16,32 @@ OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 if not OPENAI_API_KEY:
     raise RuntimeError("Missing OPENAI_API_KEY environment variable")
 
+TURNSTILE_SECRET_KEY = os.getenv("TURNSTILE_SECRET_KEY")
+
 app = FastAPI(title="Signwriting Description API")
+
+TURNSTILE_VERIFY_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
+
+
+@app.middleware("http")
+async def turnstile_verification(request: Request, call_next):
+    if request.url.path == "/health":
+        return await call_next(request)
+
+    token = request.headers.get("cf-turnstile-response")
+    if not token:
+        return JSONResponse(status_code=403, content={"error": "Missing Turnstile token"})
+
+    async with httpx.AsyncClient() as client:
+        result = await client.post(TURNSTILE_VERIFY_URL, data={
+            "secret": TURNSTILE_SECRET_KEY,
+            "response": token,
+        })
+
+    if not result.json().get("success"):
+        return JSONResponse(status_code=403, content={"error": "Invalid Turnstile token"})
+
+    return await call_next(request)
 
 
 @app.get("/health")

--- a/signwriting_description/server.py
+++ b/signwriting_description/server.py
@@ -17,6 +17,8 @@ if not OPENAI_API_KEY:
     raise RuntimeError("Missing OPENAI_API_KEY environment variable")
 
 TURNSTILE_SECRET_KEY = os.getenv("TURNSTILE_SECRET_KEY")
+if not TURNSTILE_SECRET_KEY:
+    raise RuntimeError("Missing TURNSTILE_SECRET_KEY environment variable")
 
 app = FastAPI(title="Signwriting Description API")
 
@@ -25,7 +27,7 @@ TURNSTILE_VERIFY_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverif
 
 @app.middleware("http")
 async def turnstile_verification(request: Request, call_next):
-    if request.url.path == "/health" or not TURNSTILE_SECRET_KEY:
+    if request.url.path == "/health":
         return await call_next(request)
 
     token = request.headers.get("cf-turnstile-response")

--- a/signwriting_description/server.py
+++ b/signwriting_description/server.py
@@ -17,8 +17,6 @@ if not OPENAI_API_KEY:
     raise RuntimeError("Missing OPENAI_API_KEY environment variable")
 
 TURNSTILE_SECRET_KEY = os.getenv("TURNSTILE_SECRET_KEY")
-if not TURNSTILE_SECRET_KEY:
-    raise RuntimeError("Missing TURNSTILE_SECRET_KEY environment variable")
 
 app = FastAPI(title="Signwriting Description API")
 
@@ -27,7 +25,7 @@ TURNSTILE_VERIFY_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverif
 
 @app.middleware("http")
 async def turnstile_verification(request: Request, call_next):
-    if request.url.path == "/health":
+    if request.url.path == "/health" or not TURNSTILE_SECRET_KEY:
         return await call_next(request)
 
     token = request.headers.get("cf-turnstile-response")

--- a/signwriting_description/server.py
+++ b/signwriting_description/server.py
@@ -22,7 +22,6 @@ if not TURNSTILE_SECRET_KEY:
 
 app = FastAPI(title="Signwriting Description API")
 
-TURNSTILE_VERIFY_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
 
 
 @app.middleware("http")
@@ -35,10 +34,10 @@ async def turnstile_verification(request: Request, call_next):
         return JSONResponse(status_code=403, content={"error": "Missing Turnstile token"})
 
     async with httpx.AsyncClient() as client:
-        result = await client.post(TURNSTILE_VERIFY_URL, data={
-            "secret": TURNSTILE_SECRET_KEY,
-            "response": token,
-        })
+        result = await client.post(
+            "https://challenges.cloudflare.com/turnstile/v0/siteverify",
+            data={"secret": TURNSTILE_SECRET_KEY, "response": token},
+        )
 
     if not result.json().get("success"):
         return JSONResponse(status_code=403, content={"error": "Invalid Turnstile token"})

--- a/signwriting_description/server.py
+++ b/signwriting_description/server.py
@@ -17,6 +17,8 @@ if not OPENAI_API_KEY:
     raise RuntimeError("Missing OPENAI_API_KEY environment variable")
 
 TURNSTILE_SECRET_KEY = os.getenv("TURNSTILE_SECRET_KEY")
+if not TURNSTILE_SECRET_KEY:
+    raise RuntimeError("Missing TURNSTILE_SECRET_KEY environment variable")
 
 app = FastAPI(title="Signwriting Description API")
 


### PR DESCRIPTION
## Summary
- Add FastAPI HTTP middleware that verifies Cloudflare Turnstile tokens on all endpoints except `/health`
- Reads `cf-turnstile-response` header, validates against Cloudflare siteverify API using `TURNSTILE_SECRET_KEY` env var
- Returns 403 for missing or invalid tokens

## Test plan
- [ ] Set `TURNSTILE_SECRET_KEY` env var and verify requests without token return 403
- [ ] Verify requests with valid Turnstile token return 200
- [ ] Verify `/health` endpoint remains accessible without token

🤖 Generated with [Claude Code](https://claude.com/claude-code)